### PR TITLE
Admin panel option to hide / show panel headings by Operating System

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -64,7 +64,7 @@ require_once('../lib/configsetup.inc.php');
 				<?php
 					$i = 0;
 					foreach($configsetup as $panel => $fields) {
-						if (! empty($fields['platform']) && $fields['platform'] != 'all' && $fields['platform'] != $os) {
+                                                if (! empty($fields['platform']) && $fields['platform'] != 'all' && $fields['platform'] != $os) {
                                                    continue;
                                                 };
 

--- a/admin/index.php
+++ b/admin/index.php
@@ -64,6 +64,10 @@ require_once('../lib/configsetup.inc.php');
 				<?php
 					$i = 0;
 					foreach($configsetup as $panel => $fields) {
+					        if ($fields['platform'] != 'all' && ! empty($fields['platform']) && $fields['platform'] != $os) {
+                                                   continue;
+                                                };
+
 						$open = '';
 						if($i == 0){
 							$open = ' open init';

--- a/admin/index.php
+++ b/admin/index.php
@@ -64,7 +64,7 @@ require_once('../lib/configsetup.inc.php');
 				<?php
 					$i = 0;
 					foreach($configsetup as $panel => $fields) {
-					        if ($fields['platform'] != 'all' && ! empty($fields['platform']) && $fields['platform'] != $os) {
+						if (! empty($fields['platform']) && $fields['platform'] != 'all' && $fields['platform'] != $os) {
                                                    continue;
                                                 };
 
@@ -77,6 +77,7 @@ require_once('../lib/configsetup.inc.php');
 						';
 
 						foreach($fields as $key => $field){
+                                                        if ($key == 'platform') { continue; };
 							echo '<div class="form-row">';
 							switch($field['type']) {
 								case 'input':

--- a/lib/configsetup.inc.php
+++ b/lib/configsetup.inc.php
@@ -1024,6 +1024,7 @@ $configsetup = [
 		]
 	],
 	'remotebuzzer' => [
+		'platform' => 'linux', 
 		'remotebuzzer_enabled' => [
 			'type' => 'checkbox',
 			'name' => 'remotebuzzer_enabled',

--- a/lib/configsetup.inc.php
+++ b/lib/configsetup.inc.php
@@ -1024,7 +1024,7 @@ $configsetup = [
 		]
 	],
 	'remotebuzzer' => [
-		'platform' => 'linux', 
+		'platform' => 'all', 
 		'remotebuzzer_enabled' => [
 			'type' => 'checkbox',
 			'name' => 'remotebuzzer_enabled',

--- a/lib/configsetup.inc.php
+++ b/lib/configsetup.inc.php
@@ -1024,7 +1024,7 @@ $configsetup = [
 		]
 	],
 	'remotebuzzer' => [
-		'platform' => 'all', 
+		'platform' => 'linux',
 		'remotebuzzer_enabled' => [
 			'type' => 'checkbox',
 			'name' => 'remotebuzzer_enabled',


### PR DESCRIPTION
#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/andi34/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)

- [ ] Documentation update
- [ ] Bug fix
- [X] New feature
- [ ] Other, please explain:



#### What changes did you make? (Give an overview)
For continued platform compatibility I thought it would be worthwhile to add an admin panel feature that does allow to show or hide admin panel headings (feature settings) by platform / operating system. 

This PR would add a new parameter to `configsetup.inc.php` for each panel-heading, to indicate platform compatibility:
```
'platform' => 'all'
```
Accepted values are `'all'`, `'linux'`, `'windows'`. Example:
```
        'remotebuzzer' => [
                'platform' => 'linux',
                'remotebuzzer_enabled' => [
                        'type' => 'checkbox',
                        'name' => 'remotebuzzer_enabled',
                        'value' => $config['remotebuzzer_enabled']
                ],
```

A missing `platform` key in the panel heading section defaults to `all` as value

Depending on a platform match, the panel heading / section is shown on the admin page or not.

#### Is there anything you'd like reviewers to focus on?
I don't think there is but a double-check to ensure I did not create some incompatibilities elsewhere would be great. 