### PR TITLE
install-raspbian: Pi (HQ) cam choosable at install

### DIFF
--- a/install-raspbian.sh
+++ b/install-raspbian.sh
@@ -247,6 +247,23 @@ else
     cd $INSTALLFOLDERPATH
 fi
 
+echo -e "\033[0;33m### Do you like to use a Raspberry Pi (HQ) Camera to take pictures?"
+read -p "### If yes, this will generate a personal configuration with all needed changes. [y/N] " -n 1 -r
+echo -e "\033[0m"
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    (cat << EOF) > $INSTALLFOLDERPATH/config/my.config.inc.php
+<?php
+\$config = array (
+  'take_picture' => 
+  array (
+    'cmd' => 'raspistill -n -o %s -q 100 -t 1 | echo "Done"',
+    'msg' => 'Done',
+  ),
+);
+EOF
+fi
+
 info "### Setting permissions."
 chown -R www-data:www-data $INSTALLFOLDERPATH
 gpasswd -a www-data plugdev


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/andi34/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [x] New feature

<!--
    Please ensure your pull request is ready:

    - Please run 'yarn build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'yarn eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Ask if a Raspberry Pi (HQ) camera is used, if yes setup personal config with needed changes.

#### Is there anything you'd like reviewers to focus on?
Fixes https://github.com/andi34/photobooth/issues/97 , but Install gphoto2 anyway and set proper permissions, this won't harm and makes it easy to use a DSLR later.
