### PR TITLE
gphoto: fix preview on newPic / newCollage without BSM

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -765,6 +765,10 @@ const photoBooth = (function () {
         if (config.dev.enabled) {
             console.log('Taking photo:', takingPic);
         }
+
+        if (config.preview.mode == 'gphoto' && !config.preview.gphoto_bsm) {
+            api.startVideo('preview');
+        }
     };
 
     // add image to Gallery


### PR DESCRIPTION

<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/andi34/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->
- [x] Bug fix

<!--
    Please ensure your pull request is ready:

    - Please run 'yarn build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'yarn eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
If gphoto battery saving mode is disabled, we need to call the takeVideo.php after taking an image to be able to get the preview if we take another picture from result screen.

Fix https://github.com/andi34/photobooth/issues/214