### PR TITLE
remotebuzzer: enable rotary control to access delete button

### DIFF
--- a/faq/faq.md
+++ b/faq/faq.md
@@ -203,10 +203,11 @@ Shutdown ---   GPIO 16    ---   SW
 ```
 
 Known limitations:
-The following elements are currently not supported and not accessible through the rotary navigation
+- Delete Picture: in order to be able to access the Delete button through rotary control, please activate admin setting General -> "Delete images without confirm request"
+
+The following elements are currently not supported and not accessible through rotary control navigation
 - Full Screen Mode button: Looks like modern browser only allow to change to full screen mode upon user gesture. It seems not possible to change to full-screen using Javascript.
 - Photoswipe download button: Not needed for Rotary Control. (well, if you can come up with a decent use-case, let us know).
-- Delete Picture
 
 **************
 Other Remote Trigger (experimental)

--- a/index.php
+++ b/index.php
@@ -148,7 +148,7 @@ if (
 				<?php endif; ?>
 
 				<?php if ($config['picture']['allow_delete']): ?>
-				<a href="#" class="<?php echo $btnClass1; ?> deletebtn"><i class="fa fa-trash"></i> <span data-i18n="delete"></span></a>
+				<a href="#" class="<?php echo $btnClass1; ?> deletebtn <?php if ($config['delete']['no_request']){ echo 'rotaryfocus';} ?> "><i class="fa fa-trash"></i> <span data-i18n="delete"></span></a>
 				<?php endif; ?>
 			</div>
 

--- a/template/pswp.template.php
+++ b/template/pswp.template.php
@@ -55,7 +55,7 @@
                 <?php endif; ?>
 
                 <?php if ($config['gallery']['allow_delete']): ?>
-                <button type="button" class="pswp__button pswp__button--delete" title="Delete"><i class="fa fa-trash"></i></button>
+                <button type="button" class="pswp__button pswp__button--delete <?php if ($config['delete']['no_request']){ echo 'rotaryfocus';} ?> " title="Delete"><i class="fa fa-trash"></i></button>
                 <?php endif; ?>
 
                 <!-- Preloader demo http://codepen.io/dimsemenov/pen/yyBWoR -->


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [X] I have read the [contributing guidelines](https://github.com/andi34/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [X] New feature

<!--
    Please ensure your pull request is ready:

    - Please run 'yarn build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'yarn eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Allow to access the delete buttons through rotary control (remote buzzer). Requires the setting "Delete images without confirm request" to be enabled. 

#### Is there anything you'd like reviewers to focus on?
