### PR TITLE
Fix decore line

### DIFF
--- a/template/classic.template.php
+++ b/template/classic.template.php
@@ -31,8 +31,8 @@
 				</div>
 				<?php else: ?>
 				<div class="names">
-					<hr class="small" />
 					<?php if ($config['ui']['decore_lines']): ?>
+					<hr class="small" />
 					<hr>
 					<?php endif; ?>
 					<div>


### PR DESCRIPTION
Decore line used to appear when option was turned off

<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/andi34/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [ ] Documentation update
- [x] Bug fix
- [ ] New feature
- [ ] Other, please explain:

<!--
    Please ensure your pull request is ready:

    - Please run 'yarn build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'yarn eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
The decore line in the classic template used to appear even though the option was turned off. I moved the line under the if condition.
