### PR TITLE
text on {picture,collage,print}: use color picker

### DIFF
--- a/config/config.inc.php
+++ b/config/config.inc.php
@@ -80,8 +80,7 @@ $config['textonpicture']['locationx'] = '80';
 $config['textonpicture']['locationy'] = '80';
 $config['textonpicture']['rotation'] = '0';
 $config['textonpicture']['font'] = 'resources/fonts/GreatVibes-Regular.ttf';
-// possible font_color values: 'white', 'grey', 'black'
-$config['textonpicture']['font_color'] = 'white';
+$config['textonpicture']['font_color'] = '#ffffff';
 $config['textonpicture']['font_size'] = '80';
 $config['textonpicture']['linespace'] = '90';
 
@@ -109,8 +108,7 @@ $config['textoncollage']['locationx'] = '1470';
 $config['textoncollage']['locationy'] = '250';
 $config['textoncollage']['rotation'] = '0';
 $config['textoncollage']['font'] = 'resources/fonts/GreatVibes-Regular.ttf';
-// possible font_color values: 'white', 'grey', 'black'
-$config['textoncollage']['font_color'] = 'black';
+$config['textoncollage']['font_color'] = '#000000';
 $config['textoncollage']['font_size'] = '50';
 $config['textoncollage']['linespace'] = '90';
 // DO NOT CHANGE limit here
@@ -198,8 +196,7 @@ $config['textonprint']['locationx'] = '2250';
 $config['textonprint']['locationy'] = '1050';
 $config['textonprint']['rotation'] = '40';
 $config['textonprint']['font'] = 'resources/fonts/GreatVibes-Regular.ttf';
-// possible font_color values: 'white', 'grey', 'black'
-$config['textonprint']['font_color'] = 'black';
+$config['textonprint']['font_color'] = '#ffffff';
 $config['textonprint']['font_size'] = '100';
 $config['textonprint']['linespace'] = '100';
 

--- a/lib/applyText.php
+++ b/lib/applyText.php
@@ -4,13 +4,9 @@ function ApplyText($srcImagePath, $fontsize, $fontrot, $fontlocx, $fontlocy, $fo
     $quality = 100;
     $font = realpath(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . $fontpath);
     $image = imagecreatefromjpeg($srcImagePath);
-    if ($fontcolor === 'white') {
-        $color = imagecolorallocate($image, 255, 255, 255);
-    } elseif ($fontcolor === 'grey') {
-        $color = imagecolorallocate($image, 128, 128, 128);
-    } else {
-        $color = imagecolorallocate($image, 0, 0, 0);
-    }
+    list($r, $g, $b) = sscanf($fontcolor, '#%02x%02x%02x');
+    $color = imagecolorallocate($image, $r, $g, $b);
+
     if (!empty($line1text)) {
         imagettftext($image, $fontsize, $fontrot, $fontlocx, $fontlocy, $color, $font, $line1text);
     }

--- a/lib/configsetup.inc.php
+++ b/lib/configsetup.inc.php
@@ -544,14 +544,9 @@ $configsetup = [
         ],
         'textonpicture_font_color' => [
             'view' => 'expert',
-            'type' => 'select',
+            'type' => 'color',
             'name' => 'textonpicture[font_color]',
             'placeholder' => $defaultConfig['textonpicture']['font_color'],
-            'options' => [
-                'white' => 'white',
-                'grey' => 'grey',
-                'black' => 'black',
-            ],
             'value' => $config['textonpicture']['font_color'],
         ],
         'textonpicture_font_size' => [
@@ -715,14 +710,9 @@ $configsetup = [
         ],
         'textoncollage_font_color' => [
             'view' => 'expert',
-            'type' => 'select',
+            'type' => 'color',
             'name' => 'textoncollage[font_color]',
             'placeholder' => $defaultConfig['textoncollage']['font_color'],
-            'options' => [
-                'white' => 'white',
-                'grey' => 'grey',
-                'black' => 'black',
-            ],
             'value' => $config['textoncollage']['font_color'],
         ],
         'textoncollage_font_size' => [
@@ -1204,14 +1194,9 @@ $configsetup = [
         ],
         'textonprint_font_color' => [
             'view' => 'expert',
-            'type' => 'select',
+            'type' => 'color',
             'name' => 'textonprint[font_color]',
             'placeholder' => $defaultConfig['textonprint']['font_color'],
-            'options' => [
-                'white' => 'white',
-                'grey' => 'grey',
-                'black' => 'black',
-            ],
             'value' => $config['textonprint']['font_color'],
         ],
         'textonprint_font_size' => [


### PR DESCRIPTION
<!--
    Thank you for contributing!
-->

#### Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/andi34/photobooth/blob/dev/CONTRIBUTING.md).

#### What is the purpose of this pull request? (put an "x" next to an item)
<!-- Example:
- [x] Bug fix
-->

- [x] New feature
<!--
    Please ensure your pull request is ready:

    - Please run 'yarn build' before submitting to have consistent formatting for both JavaScript & SCSS
    - Please run 'yarn eslint' to make sure there's no lint issues
-->

<!--
    The following is required for all pull requests:
-->

#### What changes did you make? (Give an overview)
Use color picker for font color. This gives the possibility to use any color instead choosing one out of three defined colors
